### PR TITLE
Simplify gradle set up process for new developers

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -35,6 +35,7 @@ captures/
 
 # Environment variables
 .env
+variables.gradle
 
 # Google play key
 app/google-play-key.json

--- a/.gitignore
+++ b/.gitignore
@@ -35,7 +35,6 @@ captures/
 
 # Environment variables
 .env
-variables.gradle
 
 # Google play key
 app/google-play-key.json

--- a/README.md
+++ b/README.md
@@ -10,10 +10,9 @@ After installing Android Studio it will walk you through downloading the most re
 
 [Gradle](https://gradle.org/) is the build tool used by Android Studio.
 
-`variables.gradle` contains environment variables such as what the API HOST is. The defaults should work
-if you have a local rails server running. When preparing for sandbox or production, please set
-the relevant variables in order to get the app to build successfully.
-
+In order to run the application, you also need a `variables.gradle` file in your root directory which stores environment variables.
+The defaults should work if you have a local rails server running.
+When preparing for sandbox or production, please set the relevant variables in order to get the app to build successfully.
 ## Build variants
 
 Our app has several different [build variants](https://developer.android.com/studio/build/build-variants.html#build-types) to represent different environments. You can create any one of these build
@@ -70,23 +69,18 @@ You now have a signed release APK that you can email, manually install on indivi
 
 ## Running app against a local server
 
-Apps with the development/spec flavor are set up to hit a local server (`http://localhost:5000` for development and `http://localhost:8000` for spec) instead of a remote heroku endpoint (e.g. `https://uhp-sandbox.watsi.org`).
+Apps with the development/spec flavor are set up to hit a local server (`http://localhost:5000` for development) instead of a remote heroku endpoint (e.g. `https://uhp-sandbox.watsi.org`).
 However, by default, emulators and devices don't know about their PC's local servers. (Going to `localhost:5000` on your emulator or device browser will attempt to access its _own_ server, which doesn't exist.)
 
-In both cases, first start your local server (see [https://github.com/Watsi/uhp-backend](https://github.com/Watsi/uhp-backend) for more detailed instructions).
+In both cases, first start your local server (see [https://github.com/meso-health/meso-backend](https://github.com/meso-health/meso-backend) for more detailed instructions).
 
 ```
 $ cd /your/path/to/uhp_backend
 ```
 
-To run local server for development:
+To run local server for development (on the backend repo):
 ```
-$ heroku local
-```
-
-To run local server for running tests:
-```
-$ rails server -e android-test -p 8000
+$ rails s -p 5000
 ```
 
 ```
@@ -121,11 +115,6 @@ For Development:
 $ adb reverse tcp:5000 tcp:5000
 ```
 
-For Spec:
-```
-$ adb reverse tcp:8000 tcp:8000
-```
-
 And voila, that's it! As long as your phone is connected to your PC, it will be able to access your PC's localhost - even without internet. Note however that you'll need to rerun this command every time you disconnect and reconnect the USB.
 
 ### Accessing your local server from your emulator
@@ -136,11 +125,6 @@ designated IP address for emulators to refer their computer's server.
 For Development:
 ```
 buildConfigField "String", "API_HOST", "\"http://10.0.2.2:5000\""
-```
-
-For Spec:
-```
-buildConfigField "String", "API_HOST", "\"http://10.0.2.2:8000\""
 ```
 
 ## Continuous Deployment
@@ -172,41 +156,8 @@ Tests can also be run from the terminal.
  ```
  # Run all unit tests for a specific build variant.
  ./gradlew test<variant_name>
-
- # Run all feature tests against development debug variant.
- ./gradlew connectedDevelopmentDebugAndroidTest
-
- # Run all feature tests for a specific build variant.
- ./gradlew connected<variant_name>AndroidTest
-
- # Run feature tests in a specific package for a specific build variant.
- ./gradlew connected<variant_name>AndroidTest -Pandroid.testInstrumentationRunnerArguments.package=<package_name>
-
- # Run specific feature test for a specific build variant.
- ./gradlew connected<variant_name>AndroidTest -Pandroid.testInstrumentationRunnerArguments.class=<package_name>
  ```
-
  More options [here](https://developer.android.com/studio/test/command-line.htm).
-
-### To run offline feature tests locally:
-```
- ./gradlew connectedSpecDebugAndroidTest -Pandroid.testInstrumentationRunnerArguments.package=org.watsi.uhp.offline
-```
-
-### To run end-to-end (online) feature tests locally:
-
-In your local UHP Backend folder:
-
-```
-# Setup android-test db with seed data:
-$ RAILS_ENV=android-test rails db:setup
-
-# Run the android-test server on port 8000:
-$ rails server -e android-test -p 8000
-
-```
-
-Then, back on the android side you can run your test locally either in Android Studio or in terminal, with either an emulator or a real connected device.
 
 ## Conventions
 

--- a/variables.gradle
+++ b/variables.gradle
@@ -1,12 +1,13 @@
-// Copy this file into a new file named variables.gradle and update the variables with the desired settings
+// These are only required for release
 gradle.ext.releaseKeystorePassword = "REPLACE_WITH_RELEASE_KEYSTORE_PASSWORD"
 gradle.ext.releaseKeyAlias = "REPLACE_WITH_RELEASE_KEY_ALIAS"
 gradle.ext.releaseKeyPassword = "REPLACE_WITH_RELEASE_KEY_PASSWORD"
-
 gradle.ext.rollbarApiKey = "\"REPLACE_WITH_ROLLBAR_API_KEY\""
 
-gradle.ext.apiHostDebug = "\"http://localhost:3000/\""
-gradle.ext.apiHostStaging = "\"http://localhost:3000/\""
-gradle.ext.apiHostDemo = "\"http://localhost:3000/\""
-gradle.ext.apiHostSandbox = "\"REPLACE_WITH_SANDBOX_URL/\""
+// This needs to be set to the port running the backend server.
+gradle.ext.apiHostDebug = "\"http://localhost:5000/\""
+
+// These are only required for sandbox / production flavor builds.
+gradle.ext.apiHostSandbox = "\"REPLACE_WITH_SANDBOX_URL\""
 gradle.ext.apiHostProduction = "\"REPLACE_WITH_PRODUCTION_URL\""
+


### PR DESCRIPTION
Makes the setup process easier for new developers.
- Moves the contents of  `variables.gradle.tmpl` into `variables.gradle` so new developers can successfully build the app without errors upon after cloning the codebase.