### PR TITLE
Set usesCleartextTraffic to false when hitting localhost

### DIFF
--- a/app/src/main/AndroidManifest.xml
+++ b/app/src/main/AndroidManifest.xml
@@ -20,6 +20,7 @@
         android:label="@string/app_name"
         android:supportsRtl="true"
         android:theme="@style/mainTheme"
+        android:usesCleartextTraffic="true"
         tools:node="merge">
 
         <service

--- a/app/src/main/AndroidManifest.xml
+++ b/app/src/main/AndroidManifest.xml
@@ -20,7 +20,7 @@
         android:label="@string/app_name"
         android:supportsRtl="true"
         android:theme="@style/mainTheme"
-        android:usesCleartextTraffic="true"
+        android:networkSecurityConfig="@xml/network_security_config"
         tools:node="merge">
 
         <service

--- a/app/src/main/res/xml/network_security_config.xml
+++ b/app/src/main/res/xml/network_security_config.xml
@@ -1,0 +1,6 @@
+<?xml version="1.0" encoding="utf-8"?>
+<network-security-config>
+    <domain-config cleartextTrafficPermitted="true">
+        <domain includeSubdomains="true">localhost:5000</domain>
+    </domain-config>
+</network-security-config>

--- a/app/src/main/res/xml/network_security_config.xml
+++ b/app/src/main/res/xml/network_security_config.xml
@@ -1,6 +1,6 @@
 <?xml version="1.0" encoding="utf-8"?>
 <network-security-config>
     <domain-config cleartextTrafficPermitted="true">
-        <domain includeSubdomains="true">localhost:5000</domain>
+        <domain includeSubdomains="true">localhost</domain>
     </domain-config>
 </network-security-config>


### PR DESCRIPTION
Ran into an issue where I wasn't able to get debug mode to hit a server hosted on http://localhost:5000.

For android devices with API level 28 or higher, `userClearTextTraffic` defaults to "false". As a result, when using the app in debug mode (i.e. things that hit http://localhost:5000) on android and app http requests will fail. This sets the clear text flag to true so if we're hitting a localhost on a android 8.0+ device, it will work.

More info in issue here:
- https://stackoverflow.com/questions/45940861/android-8-cleartext-http-traffic-not-permitted