### PR TITLE
Ability to use demo without setting up backend

### DIFF
--- a/variables.gradle
+++ b/variables.gradle
@@ -5,7 +5,7 @@ gradle.ext.releaseKeyPassword = "REPLACE_WITH_RELEASE_KEY_PASSWORD"
 gradle.ext.rollbarApiKey = "\"REPLACE_WITH_ROLLBAR_API_KEY\""
 
 // This needs to be set to the port running the backend server.
-gradle.ext.apiHostDebug = "\"http://localhost:5000/\""
+gradle.ext.apiHostDebug = "\"https://meso-backend.herokuapp.com/\""
 
 // These are only required for sandbox / production flavor builds.
 gradle.ext.apiHostSandbox = "\"REPLACE_WITH_SANDBOX_URL\""


### PR DESCRIPTION
Open question: Not sure if this should stay an open PR or be merged in. Likely I won't always check to make sure this server is up.

I've set up a server running `rake:db:seed_data` on https://meso-backend.herokuapp.com/.

All someone needs to do is check this branch out and `./installDemoDebug` and they are able to log in and click around.

